### PR TITLE
Avoid segfaults when setting the reading speed.

### DIFF
--- a/src/xcowsay.c
+++ b/src/xcowsay.c
@@ -252,7 +252,7 @@ int main(int argc, char **argv)
    parse_config_file();
    
    int c, index = 0, failure = 0;
-   const char *spec = "hvld:rt:f:";
+   const char *spec = "hvld:r:t:f:";
    const char *dream_file = NULL;
    while ((c = getopt_long(argc, argv, spec, long_options, &index)) != -1) {
       switch (c) {


### PR DESCRIPTION
Using the -r option was segfaulting, because the optstring was missing a colon.
