### PR TITLE
Signedness mismatch while reading the configuration file

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -78,7 +78,7 @@ static token_t next_token(FILE *f, strbuf_t* sbuf, int *lineno, jmp_buf *escape)
    bool skip_to_eol = false;
    bool in_quotes = false;
    for (;;) {
-      char next = fgetc(f);
+      int next = fgetc(f);
       if (EOF == next)
          return (has_chars(sbuf) && !skip_to_eol) ? tTOKEN : tEOF;
       else if ('\n' == next) {


### PR DESCRIPTION
Hi !

While building the latest release on my powerpc box, i meet this warning:

```
config_file.c:82:16: warning: result of comparison of constant -1 with expression of type 'char' is always false
```

That's happening because on some archs (notably powerpc and arm*), `char` is unsigned by default (and `EOF` is generally -1). That causes some "illegal character" error while ready my `xcowsayrc`.

Using a `signed char` fix the warning and the error message at runtime.