### PR TITLE
Set dummy $HOME, $XDG_CONFIG_HOME when testing

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -2,10 +2,8 @@
 
 set -e
 
-if [ -f "$HOME/.config/xcowsayrc" ]; then
-   mv $HOME/.config/xcowsayrc /tmp
-   trap "mv /tmp/xcowsayrc $HOME/.config/" EXIT
-fi
+export HOME=/nonexistent
+export XDG_CONFIG_HOME=/nonexistent
 
 echo Normal mode
 $BUILD_DIR/src/xcowsay Hello World


### PR DESCRIPTION
I asked the cow what she thinks about this code in `test.sh`:
```sh
if [ -f "$HOME/.config/xcowsayrc" ]; then
   mv $HOME/.config/xcowsayrc /tmp
   trap "mv /tmp/xcowsayrc $HOME/.config/" EXIT
fi
```
This was her reaction:
```
 ____________
< eww, gross >
 ------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||
```