### PR TITLE
Treat unset vars in test.sh as errors

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -e -u
 
 export HOME=/nonexistent
 export XDG_CONFIG_HOME=/nonexistent


### PR DESCRIPTION
This slightly improves the error message when one runs `test.sh` by hand.

Before:
```console
$ ./test.sh
Normal mode
./test.sh: line 9: /src/xcowsay: No such file or directory
```

After:
```console
$ ./test.sh
Normal mode
./test.sh: line 9: BUILD_DIR: unbound variable
```